### PR TITLE
VOAC-126 Restore survey link after misunderstanding by the business

### DIFF
--- a/app/uk/gov/hmrc/valuationofficeagencycontactfrontend/views/confirmation.scala.html
+++ b/app/uk/gov/hmrc/valuationofficeagencycontactfrontend/views/confirmation.scala.html
@@ -64,6 +64,8 @@
     <h2 class="heading-medium">@messages("confirmation.whatHappensnext")</h2>
     <p>@messages("confirmation.para2")</p>
 
+    <a class="print-hide" href=@messages("confirmation.survey.url") target="_self" id="survey">@messages("confirmation.survey.para")</a>
+
     @components.button_link(messageKey="site.print.button", href="javascript:window.print()", id="print-button", className="button print-hidden js-visible")
     <p><a href="http://www.gov.uk" id="backToGovUk" class="print-hide">@messages("site.govuk")</a></p>
 

--- a/test/uk/gov/hmrc/valuationofficeagencycontactfrontend/views/ConfirmationViewSpec.scala
+++ b/test/uk/gov/hmrc/valuationofficeagencycontactfrontend/views/ConfirmationViewSpec.scala
@@ -88,5 +88,12 @@ class ConfirmationViewSpec extends ViewBehaviours {
       govukUrl mustBe "http://www.gov.uk"
     }
 
+    "contain a Survey Link" in {
+      val doc = asDocument(view())
+      val survey = doc.getElementById("survey").text()
+      survey mustBe messages("confirmation.survey.para")
+      val surveyLink = doc.select("a[id=survey]").attr("href")
+      surveyLink mustBe messages("confirmation.survey.url")
+    }
   }
 }


### PR DESCRIPTION
Reinstate the survey link after a misunderstand by the business that this is required.