### PR TITLE
Downgrade play framework version.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")
 


### PR DESCRIPTION
New version(2.5.19) have different version logback which is not compatible with uk.gov.hmrc.play.logging.JsonEncoder.