### PR TITLE
Remove sbt-artifactory.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,8 +10,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.6.0")
-
 addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "4.5.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")


### PR DESCRIPTION
This plugin is needed only for jenkins and B&D choose right version during build on jenkins.